### PR TITLE
Add listener TLS certificates for VirtualNodes and VirtualGateways

### DIFF
--- a/packages/@aws-cdk/aws-appmesh/README.md
+++ b/packages/@aws-cdk/aws-appmesh/README.md
@@ -184,6 +184,42 @@ cdk.Tag.add(node, 'Environment', 'Dev');
 
 The `listeners` property can be left blank and added later with the `node.addListener()` method. The `healthcheck` and `timeout` properties are optional but if specifying a listener, the `port` must be added.
 
+## Adding TLS to a listener
+
+The `tlsCertificate` property can be added to a Virtual Node listener or Virtual Gateway listener to add TLS configuration. A certificate from AWS Certificate Manager can be incorporated or a customer provided certificate can be specified with a `certificateChain` path file and a `privateKey` file path.
+
+```typescript
+// A Virtual Node with listener TLS from an ACM provided certificate
+const cert = new Certificate(this, 'cert', {...});
+
+const node = new appmesh.VirtualNode(stack, 'node', {
+  mesh,
+  dnsHostName: 'node',
+  listeners: [appmesh.VirtualNodeListener.grpc({
+    port: 80,
+    tlsCertificate: appmesh.TlsCertificate.acm({
+      acmCertificate: cert,
+      tlsMode: TlsMode.STRICT,
+    }),
+  },
+  )],
+});
+
+// A Virtual Gateway with listener TLS from a customer provided file certificate
+const gateway = new appmesh.VirtualGateway(this, 'gateway', {
+  mesh: mesh,
+  listeners: [appmesh.VirtualGatewayListener.grpcGatewayListener({
+    port: 8080,
+    tlsCertificate: appmesh.TlsCertificate.file({
+      certificateChain: 'path/to/certChain',
+      privateKey: 'path/to/privateKey',
+      tlsMode: TlsMode.STRICT,
+    }),
+  })],
+  virtualGatewayName: 'gateway',
+});
+```
+
 ## Adding a Route
 
 A `route` is associated with a virtual router, and it's used to match requests for a virtual router and distribute traffic accordingly to its associated virtual nodes.

--- a/packages/@aws-cdk/aws-appmesh/lib/index.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/index.ts
@@ -3,6 +3,7 @@ export * from './appmesh.generated';
 export * from './mesh';
 export * from './route';
 export * from './shared-interfaces';
+export * from './tls-certificate';
 export * from './virtual-node';
 export * from './virtual-router';
 export * from './virtual-router-listener';

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-certificate.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-certificate.ts
@@ -58,6 +58,13 @@ export abstract class TlsCertificate {
   }
 
   /**
+   * The TLS mode.
+   *
+   * @default - none
+   */
+  readonly abstract tlsMode: TlsMode;
+
+  /**
    * Returns TLS certificate based provider.
    */
   public abstract bind(): TlsCertificateConfig;
@@ -70,12 +77,20 @@ export abstract class TlsCertificate {
 export class ACMTlsCertificate extends TlsCertificate {
 
   /**
+   * The TLS mode.
+   *
+   * @default - none
+   */
+  readonly tlsMode: TlsMode;
+
+  /**
    * The ARN of the ACM certificate
    */
   readonly acmCertificate: ICertificate;
 
   constructor(props: ACMCertificateOptions) {
     super();
+    this.tlsMode = props.tlsMode;
     this.acmCertificate = props.acmCertificate;
   }
 
@@ -99,10 +114,19 @@ export class ACMTlsCertificate extends TlsCertificate {
  * Represents a file provided TLS certificate
  */
 export class FileTlsCertificate extends TlsCertificate {
+
+  /**
+   * The TLS mode.
+   *
+   * @default - none
+   */
+  readonly tlsMode: TlsMode;
+
   /**
    * The file path of the certificate chain file.
    */
   readonly certificateChain: string;
+
   /**
    * The file path of the private key file.
    */
@@ -110,6 +134,7 @@ export class FileTlsCertificate extends TlsCertificate {
 
   constructor(props: FileCertificateOptions) {
     super();
+    this.tlsMode = props.tlsMode;
     this.certificateChain = props.certificateChain;
     this.privateKey = props.privateKey;
   }
@@ -136,6 +161,14 @@ export class FileTlsCertificate extends TlsCertificate {
  * ACM Certificate Properties
  */
 export interface ACMCertificateOptions {
+
+  /**
+   * The TLS mode.
+   *
+   * @default - none
+   */
+  readonly tlsMode: TlsMode;
+
   /**
    * The ACM certificate
    */
@@ -146,10 +179,19 @@ export interface ACMCertificateOptions {
  * File Certificate Properties
  */
 export interface FileCertificateOptions {
+
+  /**
+   * The TLS mode.
+   *
+   * @default - none
+   */
+  readonly tlsMode: TlsMode;
+
   /**
    * The file path of the certificate chain file.
    */
   readonly certificateChain: string;
+
   /**
    * The file path of the private key file.
    */

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-certificate.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-certificate.ts
@@ -50,8 +50,8 @@ export abstract class TlsCertificate {
   /**
    * Returns an ACM TLS Certificate
    */
-  public static acm(props: ACMCertificateOptions): TlsCertificate {
-    return new ACMTlsCertificate(props);
+  public static acm(props: AcmCertificateOptions): TlsCertificate {
+    return new AcmTlsCertificate(props);
   }
 
   /**
@@ -71,7 +71,7 @@ export abstract class TlsCertificate {
 /**
  * Represents a ACM provided TLS certificate
  */
-export class ACMTlsCertificate extends TlsCertificate {
+export class AcmTlsCertificate extends TlsCertificate {
   /**
    * The TLS mode.
    *
@@ -84,7 +84,7 @@ export class ACMTlsCertificate extends TlsCertificate {
    */
   readonly acmCertificate: acm.ICertificate;
 
-  constructor(props: ACMCertificateOptions) {
+  constructor(props: AcmCertificateOptions) {
     super();
     this.tlsMode = props.tlsMode;
     this.acmCertificate = props.acmCertificate;
@@ -155,7 +155,7 @@ export class FileTlsCertificate extends TlsCertificate {
 /**
  * ACM Certificate Properties
  */
-export interface ACMCertificateOptions {
+export interface AcmCertificateOptions {
   /**
    * The TLS mode.
    *

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-certificate.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-certificate.ts
@@ -1,0 +1,109 @@
+import { CfnVirtualNode, CfnVirtualGateway } from './appmesh.generated';
+
+/**
+ * Enum of supported TLS modes
+ */
+export enum TlsMode {
+  /**
+   * Only accept encrypted traffic
+   */
+  STRICT = 'STRICT',
+  /**
+   * Accept encrypted and plaintext traffic.
+   */
+  PERMISSIVE = 'PERMISSIVE',
+  /**
+   * TLS is disabled, only accept plaintext traffic.
+   */
+  DISABLED = 'DISABLED',
+}
+
+/**
+ * Represents a TLS certificate
+ */
+export abstract class TlsCertificate {
+
+  /**
+   * Returns TLS certificate based provider.
+   */
+  public abstract bind(): CfnVirtualNode.ListenerTlsCertificateProperty
+  | CfnVirtualGateway.VirtualGatewayListenerTlsCertificateProperty;
+
+}
+
+/**
+ * Represents a ACM provided TLS certificate
+ */
+export class AcmTlsCertificate extends TlsCertificate {
+
+  /**
+   * The ARN of the ACM certificate
+   */
+  readonly certificateArn: string;
+
+  constructor(props: ACMCertificateOptions) {
+    super();
+    this.certificateArn = props.acmCertificate;
+  }
+
+  bind(): CfnVirtualNode.ListenerTlsCertificateProperty | CfnVirtualGateway.VirtualGatewayListenerTlsCertificateProperty {
+    return {
+      acm: {
+        certificateArn: this.certificateArn,
+      },
+    };
+  }
+}
+
+/**
+ * Represents a file provided TLS certificate
+ */
+export class FileTlsCertificate extends TlsCertificate {
+  /**
+   * The file path of the certificate chain file.
+   */
+  readonly certificateChain: string;
+  /**
+   * The file path of the private key file.
+   */
+  readonly privateKey: string;
+
+  constructor(props: FileCertificateOptions) {
+    super();
+    this.certificateChain = props.certificateChain;
+    this.privateKey = props.privateKey;
+  }
+
+  bind(): CfnVirtualNode.ListenerTlsCertificateProperty | CfnVirtualGateway.VirtualGatewayListenerTlsCertificateProperty {
+    return {
+      file: {
+        certificateChain: this.certificateChain,
+        privateKey: this.privateKey,
+      },
+    };
+  }
+}
+
+/**
+ * ACM Certificate Properties
+ */
+export interface ACMCertificateOptions {
+  /**
+   * The ACM certificate
+   */
+  readonly acmCertificate: string;
+}
+
+/**
+ * File Certificate Properties
+ */
+export interface FileCertificateOptions {
+  /**
+   * The file path of the certificate chain file.
+   */
+  readonly certificateChain: string;
+  /**
+   * The file path of the private key file.
+   */
+  readonly privateKey: string;
+}

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-certificate.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-certificate.ts
@@ -1,11 +1,10 @@
-import { ICertificate } from '@aws-cdk/aws-certificatemanager';
+import * as acm from '@aws-cdk/aws-certificatemanager';
 import { CfnVirtualGateway, CfnVirtualNode } from './appmesh.generated';
 
 /**
  * Enum of supported TLS modes
  */
 export enum TlsMode {
-
   /**
    * Only accept encrypted traffic
    */
@@ -26,7 +25,6 @@ export enum TlsMode {
  * Redundant API shapes are represented here.
  */
 export interface TlsCertificateConfig {
-
   /**
    * The CFN shape for a virtual gateway listener TLS certificate
    */
@@ -42,7 +40,6 @@ export interface TlsCertificateConfig {
  * Represents a TLS certificate
  */
 export abstract class TlsCertificate {
-
   /**
    * Returns an File TLS Certificate
    */
@@ -75,7 +72,6 @@ export abstract class TlsCertificate {
  * Represents a ACM provided TLS certificate
  */
 export class ACMTlsCertificate extends TlsCertificate {
-
   /**
    * The TLS mode.
    *
@@ -86,7 +82,7 @@ export class ACMTlsCertificate extends TlsCertificate {
   /**
    * The ARN of the ACM certificate
    */
-  readonly acmCertificate: ICertificate;
+  readonly acmCertificate: acm.ICertificate;
 
   constructor(props: ACMCertificateOptions) {
     super();
@@ -114,7 +110,6 @@ export class ACMTlsCertificate extends TlsCertificate {
  * Represents a file provided TLS certificate
  */
 export class FileTlsCertificate extends TlsCertificate {
-
   /**
    * The TLS mode.
    *
@@ -161,7 +156,6 @@ export class FileTlsCertificate extends TlsCertificate {
  * ACM Certificate Properties
  */
 export interface ACMCertificateOptions {
-
   /**
    * The TLS mode.
    *
@@ -172,14 +166,13 @@ export interface ACMCertificateOptions {
   /**
    * The ACM certificate
    */
-  readonly acmCertificate: ICertificate;
+  readonly acmCertificate: acm.ICertificate;
 }
 
 /**
  * File Certificate Properties
  */
 export interface FileCertificateOptions {
-
   /**
    * The TLS mode.
    *

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway-listener.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway-listener.ts
@@ -166,10 +166,10 @@ export abstract class VirtualGatewayListener {
     return healthCheck;
   }
 
-  protected renderTls(tlsCertificate: TlsCertificate, tlsMode: TlsMode): CfnVirtualGateway.VirtualGatewayListenerTlsProperty {
+  protected renderTls(tlsCertificate: TlsCertificate): CfnVirtualGateway.VirtualGatewayListenerTlsProperty {
     return {
       certificate: tlsCertificate.bind().virtualGatewayListenerTlsCertificate,
-      mode: tlsMode.toString(),
+      mode: tlsCertificate.tlsMode.toString(),
     };
   }
 }
@@ -231,7 +231,7 @@ class HttpGatewayListener extends VirtualGatewayListener {
           protocol: this.protocol,
         },
         healthCheck: this.healthCheck ? this.renderHealthCheck(this.healthCheck): undefined,
-        tls: this.tlsCertificate && this.tlsMode ? this.renderTls(this.tlsCertificate, this.tlsMode) : undefined,
+        tls: this.tlsCertificate ? this.renderTls(this.tlsCertificate) : undefined,
       },
     };
   }
@@ -304,7 +304,7 @@ class GrpcGatewayListener extends VirtualGatewayListener {
           protocol: Protocol.GRPC,
         },
         healthCheck: this.healthCheck? this.renderHealthCheck(this.healthCheck): undefined,
-        tls: this.tlsCertificate && this.tlsMode ? this.renderTls(this.tlsCertificate, this.tlsMode) : undefined,
+        tls: this.tlsCertificate ? this.renderTls(this.tlsCertificate) : undefined,
       },
     };
   }

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-node-listener.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-node-listener.ts
@@ -141,28 +141,28 @@ export abstract class VirtualNodeListener {
    * Returns an HTTP Listener for a VirtualNode
    */
   public static http(props: HttpVirtualNodeListenerOptions = {}): VirtualNodeListener {
-    return new VirtualNodeListenerImpl(Protocol.HTTP, props.healthCheck, props.timeout, props.port, props.tlsMode, props.tlsCertificate);
+    return new VirtualNodeListenerImpl(Protocol.HTTP, props.healthCheck, props.timeout, props.port, props.tlsCertificate);
   }
 
   /**
    * Returns an HTTP2 Listener for a VirtualNode
    */
   public static http2(props: HttpVirtualNodeListenerOptions = {}): VirtualNodeListener {
-    return new VirtualNodeListenerImpl(Protocol.HTTP2, props.healthCheck, props.timeout, props.port, props.tlsMode, props.tlsCertificate);
+    return new VirtualNodeListenerImpl(Protocol.HTTP2, props.healthCheck, props.timeout, props.port, props.tlsCertificate);
   }
 
   /**
    * Returns an GRPC Listener for a VirtualNode
    */
   public static grpc(props: GrpcVirtualNodeListenerOptions = {}): VirtualNodeListener {
-    return new VirtualNodeListenerImpl(Protocol.GRPC, props.healthCheck, props.timeout, props.port, props.tlsMode, props.tlsCertificate);
+    return new VirtualNodeListenerImpl(Protocol.GRPC, props.healthCheck, props.timeout, props.port, props.tlsCertificate);
   }
 
   /**
    * Returns an TCP Listener for a VirtualNode
    */
   public static tcp(props: TcpVirtualNodeListenerOptions = {}): VirtualNodeListener {
-    return new VirtualNodeListenerImpl(Protocol.TCP, props.healthCheck, props.timeout, props.port, props.tlsMode, props.tlsCertificate);
+    return new VirtualNodeListenerImpl(Protocol.TCP, props.healthCheck, props.timeout, props.port, props.tlsCertificate);
   }
 
   /**
@@ -177,7 +177,6 @@ class VirtualNodeListenerImpl extends VirtualNodeListener {
     private readonly healthCheck: HealthCheck | undefined,
     private readonly timeout: HttpTimeout | undefined,
     private readonly port: number = 8080,
-    private readonly tlsMode: TlsMode | undefined,
     private readonly tlsCertificate: TlsCertificate | undefined) { super(); }
 
   public bind(_scope: cdk.Construct): VirtualNodeListenerConfig {
@@ -189,7 +188,7 @@ class VirtualNodeListenerImpl extends VirtualNodeListener {
         },
         healthCheck: this.healthCheck ? this.renderHealthCheck(this.healthCheck) : undefined,
         timeout: this.timeout ? this.renderTimeout(this.timeout) : undefined,
-        tls: this.tlsCertificate && this.tlsMode ? this.renderTls(this.tlsCertificate, this.tlsMode) : undefined,
+        tls: this.tlsCertificate ? this.renderTls(this.tlsCertificate) : undefined,
       },
     };
   }
@@ -235,10 +234,10 @@ class VirtualNodeListenerImpl extends VirtualNodeListener {
     });
   }
 
-  private renderTls(tlsCertificate: TlsCertificate, tlsMode: TlsMode): CfnVirtualNode.ListenerTlsProperty {
+  private renderTls(tlsCertificate: TlsCertificate): CfnVirtualNode.ListenerTlsProperty {
     return {
       certificate: tlsCertificate.bind().virtualNodeListenerTlsCertificate,
-      mode: tlsMode.toString(),
+      mode: tlsCertificate.tlsMode.toString(),
     };
   }
 }

--- a/packages/@aws-cdk/aws-appmesh/package.json
+++ b/packages/@aws-cdk/aws-appmesh/package.json
@@ -88,6 +88,7 @@
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-iam": "0.0.0",
     "@aws-cdk/aws-servicediscovery": "0.0.0",
+    "@aws-cdk/aws-acmpca": "0.0.0",
     "@aws-cdk/core": "0.0.0",
     "constructs": "^3.2.0"
   },
@@ -96,7 +97,8 @@
     "@aws-cdk/aws-iam": "0.0.0",
     "@aws-cdk/aws-servicediscovery": "0.0.0",
     "@aws-cdk/core": "0.0.0",
-    "constructs": "^3.2.0"
+    "constructs": "^3.2.0",
+    "@aws-cdk/aws-acmpca": "0.0.0"
   },
   "engines": {
     "node": ">= 10.13.0 <13 || >=13.7.0"

--- a/packages/@aws-cdk/aws-appmesh/package.json
+++ b/packages/@aws-cdk/aws-appmesh/package.json
@@ -93,13 +93,12 @@
     "constructs": "^3.2.0"
   },
   "peerDependencies": {
+    "@aws-cdk/aws-certificatemanager": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-iam": "0.0.0",
     "@aws-cdk/aws-servicediscovery": "0.0.0",
     "@aws-cdk/core": "0.0.0",
-    "constructs": "^3.2.0",
-    "@aws-cdk/aws-acmpca": "0.0.0",
-    "@aws-cdk/aws-certificatemanager": "0.0.0"
+    "constructs": "^3.2.0"
   },
   "engines": {
     "node": ">= 10.13.0 <13 || >=13.7.0"

--- a/packages/@aws-cdk/aws-appmesh/package.json
+++ b/packages/@aws-cdk/aws-appmesh/package.json
@@ -85,10 +85,10 @@
     "pkglint": "0.0.0"
   },
   "dependencies": {
+    "@aws-cdk/aws-certificatemanager": "0.0.0",
     "@aws-cdk/aws-ec2": "0.0.0",
     "@aws-cdk/aws-iam": "0.0.0",
     "@aws-cdk/aws-servicediscovery": "0.0.0",
-    "@aws-cdk/aws-acmpca": "0.0.0",
     "@aws-cdk/core": "0.0.0",
     "constructs": "^3.2.0"
   },
@@ -98,7 +98,8 @@
     "@aws-cdk/aws-servicediscovery": "0.0.0",
     "@aws-cdk/core": "0.0.0",
     "constructs": "^3.2.0",
-    "@aws-cdk/aws-acmpca": "0.0.0"
+    "@aws-cdk/aws-acmpca": "0.0.0",
+    "@aws-cdk/aws-certificatemanager": "0.0.0"
   },
   "engines": {
     "node": ">= 10.13.0 <13 || >=13.7.0"

--- a/packages/@aws-cdk/aws-appmesh/test/integ.mesh.expected.json
+++ b/packages/@aws-cdk/aws-appmesh/test/integ.mesh.expected.json
@@ -1,5 +1,64 @@
 {
   "Resources": {
+    "CA": {
+      "Type": "AWS::ACMPCA::CertificateAuthority",
+      "Properties": {
+        "KeyAlgorithm": "RSA_2048",
+        "SigningAlgorithm": "SHA256WITHRSA",
+        "Subject": {
+          "Country": "US",
+          "State": "Washington",
+          "Locality": "Seattle",
+          "Organization": "App Mesh",
+          "OrganizationalUnit": "cdk test"
+        },
+        "Type": "ROOT"
+      }
+    },
+    "vgcert": {
+      "Type": "AWS::ACMPCA::Certificate",
+      "Properties": {
+        "CertificateAuthorityArn": {
+          "Fn::GetAtt": [
+            "CA",
+            "Arn"
+          ]
+        },
+        "CertificateSigningRequest": {
+          "Fn::GetAtt": [
+            "CA",
+            "CertificateSigningRequest"
+          ]
+        },
+        "SigningAlgorithm": "SHA256WITHRSA",
+        "Validity": {
+          "Value": 365,
+          "Type": "DAYS"
+        }
+      }
+    },
+    "vncert": {
+      "Type": "AWS::ACMPCA::Certificate",
+      "Properties": {
+        "CertificateAuthorityArn": {
+          "Fn::GetAtt": [
+            "CA",
+            "Arn"
+          ]
+        },
+        "CertificateSigningRequest": {
+          "Fn::GetAtt": [
+            "CA",
+            "CertificateSigningRequest"
+          ]
+        },
+        "SigningAlgorithm": "SHA256WITHRSA",
+        "Validity": {
+          "Value": 365,
+          "Type": "DAYS"
+        }
+      }
+    },
     "vpcA2121C38": {
       "Type": "AWS::EC2::VPC",
       "Properties": {
@@ -669,6 +728,19 @@
               "PortMapping": {
                 "Port": 8080,
                 "Protocol": "http"
+              },
+              "TLS": {
+                "Certificate": {
+                  "ACM": {
+                    "CertificateArn": {
+                      "Fn::GetAtt": [
+                        "vncert",
+                        "Arn"
+                      ]
+                    }
+                  }
+                },
+                "Mode": "STRICT"
               }
             }
           ],
@@ -967,6 +1039,19 @@
               "PortMapping": {
                 "Port": 443,
                 "Protocol": "http"
+              },
+              "TLS": {
+                "Certificate": {
+                  "ACM": {
+                    "CertificateArn": {
+                      "Fn::GetAtt": [
+                        "vgcert",
+                        "Arn"
+                      ]
+                    }
+                  }
+                },
+                "Mode": "STRICT"
               }
             }
           ]

--- a/packages/@aws-cdk/aws-appmesh/test/integ.mesh.expected.json
+++ b/packages/@aws-cdk/aws-appmesh/test/integ.mesh.expected.json
@@ -1,64 +1,5 @@
 {
   "Resources": {
-    "CA": {
-      "Type": "AWS::ACMPCA::CertificateAuthority",
-      "Properties": {
-        "KeyAlgorithm": "RSA_2048",
-        "SigningAlgorithm": "SHA256WITHRSA",
-        "Subject": {
-          "Country": "US",
-          "State": "Washington",
-          "Locality": "Seattle",
-          "Organization": "App Mesh",
-          "OrganizationalUnit": "cdk test"
-        },
-        "Type": "ROOT"
-      }
-    },
-    "vgcert": {
-      "Type": "AWS::ACMPCA::Certificate",
-      "Properties": {
-        "CertificateAuthorityArn": {
-          "Fn::GetAtt": [
-            "CA",
-            "Arn"
-          ]
-        },
-        "CertificateSigningRequest": {
-          "Fn::GetAtt": [
-            "CA",
-            "CertificateSigningRequest"
-          ]
-        },
-        "SigningAlgorithm": "SHA256WITHRSA",
-        "Validity": {
-          "Value": 365,
-          "Type": "DAYS"
-        }
-      }
-    },
-    "vncert": {
-      "Type": "AWS::ACMPCA::Certificate",
-      "Properties": {
-        "CertificateAuthorityArn": {
-          "Fn::GetAtt": [
-            "CA",
-            "Arn"
-          ]
-        },
-        "CertificateSigningRequest": {
-          "Fn::GetAtt": [
-            "CA",
-            "CertificateSigningRequest"
-          ]
-        },
-        "SigningAlgorithm": "SHA256WITHRSA",
-        "Validity": {
-          "Value": 365,
-          "Type": "DAYS"
-        }
-      }
-    },
     "vpcA2121C38": {
       "Type": "AWS::EC2::VPC",
       "Properties": {
@@ -731,13 +672,9 @@
               },
               "TLS": {
                 "Certificate": {
-                  "ACM": {
-                    "CertificateArn": {
-                      "Fn::GetAtt": [
-                        "vncert",
-                        "Arn"
-                      ]
-                    }
+                  "File": {
+                    "CertificateChain": "path/to/certChain",
+                    "PrivateKey": "path/to/privateKey"
                   }
                 },
                 "Mode": "STRICT"
@@ -1042,13 +979,9 @@
               },
               "TLS": {
                 "Certificate": {
-                  "ACM": {
-                    "CertificateArn": {
-                      "Fn::GetAtt": [
-                        "vgcert",
-                        "Arn"
-                      ]
-                    }
+                  "File": {
+                    "CertificateChain": "path/to/certChain",
+                    "PrivateKey": "path/to/privateKey"
                   }
                 },
                 "Mode": "STRICT"

--- a/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
@@ -1,4 +1,3 @@
-import { Certificate } from '@aws-cdk/aws-certificatemanager';
 import * as ec2 from '@aws-cdk/aws-ec2';
 import * as cloudmap from '@aws-cdk/aws-servicediscovery';
 import * as cdk from '@aws-cdk/core';
@@ -16,14 +15,6 @@ const vpc = new ec2.Vpc(stack, 'vpc', {
 const namespace = new cloudmap.PrivateDnsNamespace(stack, 'test-namespace', {
   vpc,
   name: 'domain.local',
-});
-
-const vg_cert = new Certificate(stack, 'vg-cert', {
-  domainName: 'gateway.cluster.local',
-});
-
-const vn_cert = new Certificate(stack, 'vn-cert', {
-  domainName: 'node.cluster.local',
 });
 
 const mesh = new appmesh.Mesh(stack, 'mesh');
@@ -45,9 +36,10 @@ const node = mesh.addVirtualNode('node', {
       healthyThreshold: 3,
       path: '/check-path',
     },
-    tlsMode: appmesh.TlsMode.STRICT,
-    tlsCertificate: appmesh.TlsCertificate.acm({
-      acmCertificate: vn_cert,
+    tlsCertificate: appmesh.TlsCertificate.file({
+      certificateChain: 'path/to/certChain',
+      privateKey: 'path/to/privateKey',
+      tlsMode: appmesh.TlsMode.STRICT,
     }),
   })],
   backends: [
@@ -139,9 +131,10 @@ new appmesh.VirtualGateway(stack, 'gateway2', {
     healthCheck: {
       interval: cdk.Duration.seconds(10),
     },
-    tlsMode: appmesh.TlsMode.STRICT,
-    tlsCertificate: appmesh.TlsCertificate.acm({
-      acmCertificate: vg_cert,
+    tlsCertificate: appmesh.TlsCertificate.file({
+      certificateChain: 'path/to/certChain',
+      privateKey: 'path/to/privateKey',
+      tlsMode: appmesh.TlsMode.STRICT,
     }),
   })],
 });

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
@@ -173,8 +173,8 @@ export = {
         mesh: mesh,
         listeners: [appmesh.VirtualGatewayListener.httpGatewayListener({
           port: 8080,
-          tlsMode: TlsMode.STRICT,
           tlsCertificate: appmesh.TlsCertificate.acm({
+            tlsMode: TlsMode.STRICT,
             acmCertificate: cert,
           }),
         })],
@@ -194,7 +194,7 @@ export = {
                 Certificate: {
                   ACM: {
                     CertificateArn: {
-                      'Fn::GetAtt': ['cert', 'Arn'],
+                      Ref: 'cert56CA94EB',
                     },
                   },
                 },
@@ -220,10 +220,10 @@ export = {
         mesh: mesh,
         listeners: [appmesh.VirtualGatewayListener.grpcGatewayListener({
           port: 8080,
-          tlsMode: TlsMode.STRICT,
           tlsCertificate: appmesh.TlsCertificate.file({
             certificateChain: 'path/to/certChain',
             privateKey: 'path/to/privateKey',
+            tlsMode: TlsMode.STRICT,
           }),
         })],
       });
@@ -267,10 +267,10 @@ export = {
         mesh: mesh,
         listeners: [appmesh.VirtualGatewayListener.grpcGatewayListener({
           port: 8080,
-          tlsMode: TlsMode.PERMISSIVE,
           tlsCertificate: appmesh.TlsCertificate.file({
             certificateChain: 'path/to/certChain',
             privateKey: 'path/to/privateKey',
+            tlsMode: TlsMode.PERMISSIVE,
           }),
         })],
       });

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
@@ -190,7 +190,7 @@ export = {
                 Protocol: appmesh.Protocol.HTTP,
               },
               TLS: {
-                Mode: 'STRICT',
+                Mode: TlsMode.STRICT,
                 Certificate: {
                   ACM: {
                     CertificateArn: {
@@ -238,7 +238,7 @@ export = {
                 Protocol: appmesh.Protocol.GRPC,
               },
               TLS: {
-                Mode: 'STRICT',
+                Mode: TlsMode.STRICT,
                 Certificate: {
                   File: {
                     CertificateChain: 'path/to/certChain',
@@ -285,7 +285,7 @@ export = {
                 Protocol: appmesh.Protocol.GRPC,
               },
               TLS: {
-                Mode: 'PERMISSIVE',
+                Mode: TlsMode.PERMISSIVE,
                 Certificate: {
                   File: {
                     CertificateChain: 'path/to/certChain',

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
@@ -1,8 +1,10 @@
 import { expect, haveResourceLike } from '@aws-cdk/assert';
+import { CfnCertificate, CfnCertificateAuthority } from '@aws-cdk/aws-acmpca';
 import * as cdk from '@aws-cdk/core';
 import { Test } from 'nodeunit';
 
 import * as appmesh from '../lib';
+import { FileTlsCertificate, TlsMode } from '../lib/tls-certificate';
 
 export = {
   'When creating a VirtualGateway': {
@@ -151,6 +153,174 @@ export = {
         },
         VirtualGatewayName: 'test-gateway',
       }));
+      test.done();
+    },
+    'with an http listener with a TLS certificate from ACM'(test: Test) {
+      // GIVEN
+      const stack = new cdk.Stack();
+
+      // WHEN
+      const mesh = new appmesh.Mesh(stack, 'mesh', {
+        meshName: 'test-mesh',
+      });
+
+      const ca = new CfnCertificateAuthority(stack, 'CA', {
+        keyAlgorithm: 'RSA_2048',
+        signingAlgorithm: 'SHA256WITHRSA',
+        subject: {
+          country: 'US',
+          state: 'Washington',
+          locality: 'Seattle',
+          organization: 'App Mesh',
+          organizationalUnit: 'cdk test',
+        },
+        type: 'ROOT',
+      });
+
+      const cert = new CfnCertificate(stack, 'cert', {
+        certificateAuthorityArn: ca.attrArn,
+        certificateSigningRequest: ca.attrCertificateSigningRequest,
+        signingAlgorithm: 'SHA256WITHRSA',
+        validity: {
+          value: 365,
+          type: 'DAYS',
+        },
+      });
+
+      new appmesh.VirtualGateway(stack, 'testGateway', {
+        virtualGatewayName: 'test-gateway',
+        mesh: mesh,
+        listeners: [appmesh.VirtualGatewayListener.httpGatewayListener({
+          port: 8080,
+          tls: {
+            mode: TlsMode.STRICT,
+            certificate: cert,
+          },
+        })],
+      });
+
+      // THEN
+      expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualGateway', {
+        Spec: {
+          Listeners: [
+            {
+              PortMapping: {
+                Port: 8080,
+                Protocol: appmesh.Protocol.HTTP,
+              },
+              TLS: {
+                Mode: 'STRICT',
+                Certificate: {
+                  ACM: {
+                    CertificateArn: {
+                      'Fn::GetAtt': ['cert', 'Arn'],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }));
+
+      test.done();
+    },
+    'with an grpc listener with a TLS certificate from file'(test: Test) {
+      // GIVEN
+      const stack = new cdk.Stack();
+
+      // WHEN
+      const mesh = new appmesh.Mesh(stack, 'mesh', {
+        meshName: 'test-mesh',
+      });
+
+      new appmesh.VirtualGateway(stack, 'testGateway', {
+        virtualGatewayName: 'test-gateway',
+        mesh: mesh,
+        listeners: [appmesh.VirtualGatewayListener.grpcGatewayListener({
+          port: 8080,
+          tls: {
+            mode: TlsMode.STRICT,
+            certificate: new FileTlsCertificate({
+              certificateChain: 'path/to/certChain',
+              privateKey: 'path/to/privateKey',
+            }),
+          },
+        })],
+      });
+
+      // THEN
+      expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualGateway', {
+        Spec: {
+          Listeners: [
+            {
+              PortMapping: {
+                Port: 8080,
+                Protocol: appmesh.Protocol.GRPC,
+              },
+              TLS: {
+                Mode: 'STRICT',
+                Certificate: {
+                  File: {
+                    CertificateChain: 'path/to/certChain',
+                    PrivateKey: 'path/to/privateKey',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }));
+
+      test.done();
+    },
+    'with an grpc listener with the TLS mode permissive'(test: Test) {
+      // GIVEN
+      const stack = new cdk.Stack();
+
+      // WHEN
+      const mesh = new appmesh.Mesh(stack, 'mesh', {
+        meshName: 'test-mesh',
+      });
+
+      new appmesh.VirtualGateway(stack, 'testGateway', {
+        virtualGatewayName: 'test-gateway',
+        mesh: mesh,
+        listeners: [appmesh.VirtualGatewayListener.grpcGatewayListener({
+          port: 8080,
+          tls: {
+            mode: TlsMode.PERMISSIVE,
+            certificate: new FileTlsCertificate({
+              certificateChain: 'path/to/certChain',
+              privateKey: 'path/to/privateKey',
+            }),
+          },
+        })],
+      });
+
+      // THEN
+      expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualGateway', {
+        Spec: {
+          Listeners: [
+            {
+              PortMapping: {
+                Port: 8080,
+                Protocol: appmesh.Protocol.GRPC,
+              },
+              TLS: {
+                Mode: 'PERMISSIVE',
+                Certificate: {
+                  File: {
+                    CertificateChain: 'path/to/certChain',
+                    PrivateKey: 'path/to/privateKey',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }));
+
       test.done();
     },
   },

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
@@ -294,7 +294,7 @@ export = {
                   Protocol: 'grpc',
                 },
                 TLS: {
-                  Mode: 'STRICT',
+                  Mode: TlsMode.STRICT,
                   Certificate: {
                     ACM: {
                       CertificateArn: {
@@ -344,7 +344,7 @@ export = {
                   Protocol: 'http',
                 },
                 TLS: {
-                  Mode: 'STRICT',
+                  Mode: TlsMode.STRICT,
                   Certificate: {
                     File: {
                       CertificateChain: 'path/to/certChain',
@@ -392,7 +392,7 @@ export = {
                     Protocol: 'http',
                   },
                   TLS: {
-                    Mode: 'PERMISSIVE',
+                    Mode: TlsMode.PERMISSIVE,
                     Certificate: {
                       File: {
                         CertificateChain: 'path/to/certChain',

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
@@ -276,9 +276,9 @@ export = {
           dnsHostName: 'test',
           listeners: [appmesh.VirtualNodeListener.grpc({
             port: 80,
-            tlsMode: TlsMode.STRICT,
             tlsCertificate: appmesh.TlsCertificate.acm({
               acmCertificate: cert,
+              tlsMode: TlsMode.STRICT,
             }),
           },
           )],
@@ -298,7 +298,7 @@ export = {
                   Certificate: {
                     ACM: {
                       CertificateArn: {
-                        'Fn::GetAtt': ['cert', 'Arn'],
+                        Ref: 'cert56CA94EB',
                       },
                     },
                   },
@@ -326,10 +326,10 @@ export = {
           dnsHostName: 'test',
           listeners: [appmesh.VirtualNodeListener.http({
             port: 80,
-            tlsMode: TlsMode.STRICT,
             tlsCertificate: appmesh.TlsCertificate.file({
               certificateChain: 'path/to/certChain',
               privateKey: 'path/to/privateKey',
+              tlsMode: TlsMode.STRICT,
             }),
           })],
         });
@@ -374,10 +374,10 @@ export = {
             dnsHostName: 'test',
             listeners: [appmesh.VirtualNodeListener.http({
               port: 80,
-              tlsMode: TlsMode.PERMISSIVE,
               tlsCertificate: appmesh.TlsCertificate.file({
                 certificateChain: 'path/to/certChain',
                 privateKey: 'path/to/privateKey',
+                tlsMode: TlsMode.PERMISSIVE,
               }),
             })],
           });


### PR DESCRIPTION
Includes unit and integ tests. Adds a dependency on ACM. Some notes because I don't know typescript or cdk:

1. It looks like the CDK integration for ACM isn't there yet. It looks like its safe to rely on the generated cfn structures and we can migrate whenever ACM writes their integration. 
2. Do my `bind()` functions need to consume scope?

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
